### PR TITLE
Update README files to English-only versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
 # AI Developer Workflow Collection
 
-[English](#english) | [ภาษาไทย](#thai)
-
----
-
-## <a name="english"></a>English Version
-
 This repository contains a collection of AI-powered workflows designed to help developers automate, streamline, and enhance their software development processes. Each workflow is organized in its own subdirectory and is focused on a specific aspect of the developer experience.
 
-### Repository Structure
+## Repository Structure
 
 - Each subdirectory contains a self-contained workflow, documentation, and supporting scripts or markdown guides.
 - Workflows are designed to be modular and reusable.
 
-### Current Workflows
+## Current Workflows
 
-#### prd-driven-workflow
+### PRD-Driven Workflow
 A workflow for Product Requirements Document (PRD)-driven development. It includes guides and scripts to:
 - Create PRDs
 - Generate actionable tasks from PRDs
@@ -23,53 +17,21 @@ A workflow for Product Requirements Document (PRD)-driven development. It includ
 
 (See `/prd-driven-workflow/README.md` for details.)
 
-### Getting Started
+### Review-Driven Workflow
+A comprehensive AI-powered code review system that integrates specialized reviewers, GitLab automation, and educational feedback to ensure high-quality code delivery.
+
+(See `/review-driven-workflow/README.md` for details.)
+
+## Getting Started
 
 1. Clone this repository.
 2. Explore the subdirectories for workflow-specific instructions.
 3. Follow the guides or scripts in each workflow to automate or enhance your development process.
 
-### Contributing
+## Contributing
 
 Contributions are welcome! Please open issues or pull requests to suggest new workflows or improvements.
 
-### License
+## License
 
 This project is licensed under the terms of the LICENSE file in the root directory.
-
----
-
-## <a name="thai"></a>ภาษาไทย
-
-คลังเวิร์กโฟลว์สำหรับนักพัฒนาที่ใช้ AI
-
-Repository นี้ประกอบด้วยชุดเวิร์กโฟลว์ที่ขับเคลื่อนด้วย AI ซึ่งออกแบบมาเพื่อช่วยให้นักพัฒนาสามารถทำงานอัตโนมัติ ปรับปรุงประสิทธิภาพ และพัฒนากระบวนการพัฒนาซอฟต์แวร์ของพวกเขา แต่ละเวิร์กโฟลว์จะถูกจัดระเบียบในไดเรกทอรีย่อยของตัวเอง และมุ่งเน้นไปที่แง่มุมเฉพาะของประสบการณ์การพัฒนา
-
-### โครงสร้าง Repository
-
-- แต่ละไดเรกทอรีย่อยประกอบด้วยเวิร์กโฟลว์ที่สมบูรณ์ในตัวเอง เอกสารประกอบ และสคริปต์หรือคู่มือ markdown ที่สนับสนุน
-- เวิร์กโฟลว์ถูกออกแบบให้เป็นโมดูลและนำกลับมาใช้ใหม่ได้
-
-### เวิร์กโฟลว์ปัจจุบัน
-
-#### prd-driven-workflow (เวิร์กโฟลว์ที่ขับเคลื่อนด้วย PRD)
-เวิร์กโฟลว์สำหรับการพัฒนาที่ขับเคลื่อนด้วยเอกสารข้อกำหนดผลิตภัณฑ์ (Product Requirements Document - PRD) ประกอบด้วยคู่มือและสคริปต์สำหรับ:
-- สร้าง PRDs (เอกสารข้อกำหนดผลิตภัณฑ์)
-- สร้างงานที่สามารถดำเนินการได้จาก PRDs
-- ประมวลผลและจัดการรายการงาน
-
-(ดูรายละเอียดที่ `/prd-driven-workflow/README.md`)
-
-### เริ่มต้นใช้งาน
-
-1. Clone repository นี้
-2. สำรวจไดเรกทอรีย่อยสำหรับคำแนะนำเฉพาะของแต่ละเวิร์กโฟลว์
-3. ปฏิบัติตามคู่มือหรือสคริปต์ในแต่ละเวิร์กโฟลว์เพื่อทำให้กระบวนการพัฒนาของคุณเป็นอัตโนมัติหรือพัฒนาให้ดีขึ้น
-
-### การมีส่วนร่วม
-
-ยินดีรับการมีส่วนร่วม! กรุณาเปิด issues หรือ pull requests เพื่อเสนอเวิร์กโฟลว์ใหม่หรือการปรับปรุง
-
-### สัญญาอนุญาต
-
-โครงการนี้อยู่ภายใต้เงื่อนไขของไฟล์ LICENSE ในไดเรกทอรีหลัก

--- a/prd-driven-workflow/README.md
+++ b/prd-driven-workflow/README.md
@@ -1,17 +1,11 @@
 # PRD-Driven Workflow
 
-[English](#english) | [ภาษาไทย](#thai)
-
----
-
-## <a name="english"></a>English Version
-
 This workflow provides a structured, AI-assisted approach to Product Requirements Document (PRD)-driven development. It helps you:
 - Create clear PRDs
 - Break down PRDs into actionable tasks
 - Process and manage task lists for implementation
 
-### Included Guides
+## Included Guides
 
 - `01-create-prd.md`: Guide to creating a PRD
 - `02-generate-tasks.md`: How to generate tasks from a PRD
@@ -22,50 +16,17 @@ Replit-specific versions are also included for users working in the Replit envir
 - `02-generate-tasks-replit.md`
 - `03-process-tasks-replit.md`
 
-### Usage
+## Usage
 
 1. Start with `01-create-prd.md` to draft your PRD.
 2. Use `02-generate-tasks.md` to break down the PRD into tasks.
 3. Follow `03-process-task-list.md` to manage and execute the tasks.
 
-### Goals
+## Goals
 
 - Streamline the transition from requirements to actionable development tasks
 - Leverage AI to automate and enhance the workflow
 
 ---
 
-## <a name="thai"></a>ภาษาไทย
-
-เวิร์กโฟลว์ที่ขับเคลื่อนด้วย PRD
-
-เวิร์กโฟลว์นี้ให้แนวทางที่มีโครงสร้างและใช้ AI ช่วยในการพัฒนาที่ขับเคลื่อนด้วยเอกสารข้อกำหนดผลิตภัณฑ์ (Product Requirements Document - PRD) ซึ่งจะช่วยคุณ:
-- สร้าง PRDs ที่ชัดเจน
-- แบ่งย่อย PRDs เป็นงานที่สามารถดำเนินการได้
-- ประมวลผลและจัดการรายการงานสำหรับการนำไปใช้
-
-### คู่มือที่รวมอยู่
-
-- `01-create-prd.md`: คู่มือการสร้าง PRD
-- `02-generate-tasks.md`: วิธีการสร้างงานจาก PRD
-- `03-process-task-list.md`: การประมวลผลและจัดการรายการงานที่สร้างขึ้น
-
-เวอร์ชันเฉพาะสำหรับ Replit สำหรับผู้ใช้ที่ทำงานในสภาพแวดล้อม Replit:
-- `01-create-prd-replit.md`
-- `02-generate-tasks-replit.md`
-- `03-process-tasks-replit.md`
-
-### วิธีใช้งาน
-
-1. เริ่มต้นด้วย `01-create-prd.md` เพื่อร่าง PRD ของคุณ
-2. ใช้ `02-generate-tasks.md` เพื่อแบ่งย่อย PRD เป็นงานต่างๆ
-3. ปฏิบัติตาม `03-process-task-list.md` เพื่อจัดการและดำเนินการงาน
-
-### เป้าหมาย
-
-- ปรับปรุงการเปลี่ยนผ่านจากข้อกำหนดไปสู่งานพัฒนาที่สามารถดำเนินการได้
-- ใช้ประโยชน์จาก AI เพื่อทำให้เวิร์กโฟลว์เป็นอัตโนมัติและพัฒนาให้ดีขึ้น
-
----
-
-For more workflows, see the main [README](../README.md) | สำหรับเวิร์กโฟลว์เพิ่มเติม ดูที่ [README](../README.md) หลัก
+For more workflows, see the main [README](../README.md).


### PR DESCRIPTION
Fixes #4

This PR updates all README.md files to remove Thai language sections and provide English-only versions as requested.

## Changes
- Removed Thai language sections from root README.md
- Removed Thai language sections from prd-driven-workflow/README.md
- Added description for review-driven workflow to root README
- Maintained all essential information in clean, English-only format

Generated with [Claude Code](https://claude.ai/code)